### PR TITLE
Experiment with not indicating shell prompt

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -239,7 +239,7 @@ class Step < Erector::Widget
   def console_with_message(message, commands)
     div :class => "console" do
       span message
-      pre "$ " + commands
+      pre commands
     end
   end
 

--- a/sites/en/intro-to-rails/intro-to-rails.step
+++ b/sites/en/intro-to-rails/intro-to-rails.step
@@ -53,13 +53,11 @@ show up for RailsBridge on Saturday.
 You can verify that you have everything working by trying this out in your terminal:
 
 <div class="console"><pre>
-$ irb
 >> 1 + 2
 => 3
 >> require "active_support"
 => true
 >> exit
-$
 </pre>
 </div>
 

--- a/spec/step_spec.rb
+++ b/spec/step_spec.rb
@@ -120,7 +120,7 @@ describe Step do
       assert_loosely_equal(@html, <<-HTML)
 <div class="console">
   <span>#{Step::TERMINAL_CAPTION}</span>
-  <pre>$ echo hi</pre>
+  <pre>echo hi</pre>
 </div>
       HTML
     end


### PR DESCRIPTION
The dollar prompt that is used in the console has, in the past, seemed to create confusion for the attendees. I was wondering if we could try without the dollar prompt and see if it has any better results?
